### PR TITLE
Feat/send mail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@
 # Editors
 *.vs_code/
 *.idea/
+
+# Temp
+*tmp/
+
+# Air
+*.air.toml

--- a/controllers/subscribe.go
+++ b/controllers/subscribe.go
@@ -14,7 +14,7 @@ import (
 func Subscribe(ctx echo.Context) error {
 	user := &models.Subscriber{}
 	err := ctx.Bind(user)
-	sessionName := ctx.Param("sessionName")
+	sessionName := ctx.Param("speaker")
 
 	if err != nil {
 		logs.Output(

--- a/db/query.go
+++ b/db/query.go
@@ -3,7 +3,6 @@ package db
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"numenv_subscription_api/errors/logs"
 	"reflect"
 )
@@ -29,8 +28,6 @@ func Exec[T any](
 		value := reflect.ValueOf(data).Field(i).Interface()
 		arrayValues[i] = value
 	}
-
-	fmt.Println(arrayValues...)
 
 	_, err = query.ExecContext(
 		ctx,

--- a/errors/logs/log.go
+++ b/errors/logs/log.go
@@ -22,7 +22,7 @@ func Output(logLevel LogLevel, errMsg string) {
   l := log.New(
     os.Stderr,
     fmt.Sprintf("%s: ", logLevel.String()),
-    1,
+    0,
   )
   l.Print(errMsg)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/labstack/echo/v4 v4.11.3 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
+	github.com/mailjet/mailjet-apiv3-go v0.0.0-20201009050126-c24bc15a9394 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,12 @@ github.com/labstack/gommon v0.4.0 h1:y7cvthEAEbU0yHOf4axH8ZG2NH8knB9iNSoTO8dyIk8
 github.com/labstack/gommon v0.4.0/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mailjet/mailjet-apiv3-go v0.0.0-20201009050126-c24bc15a9394 h1:+6kiV40vfmh17TDlZG15C2uGje1/XBGT32j6xKmUkqM=
+github.com/mailjet/mailjet-apiv3-go v0.0.0-20201009050126-c24bc15a9394/go.mod h1:ogN8Sxy3n5VKLhQxbtSBM3ICG/VgjXS/akQJIoDSrgA=
+github.com/mailjet/mailjet-apiv3-go/v3 v3.2.0 h1:/gjowTurgK4iqLzVAQmjtcldyaW6tbJNA4PzZsuj2Ks=
+github.com/mailjet/mailjet-apiv3-go/v3 v3.2.0/go.mod h1:Nw3mVzRxV0CVDTlzaRcADGKt4PMNbT7gYIyEtjMrVIM=
+github.com/mailjet/mailjet-apiv3-go/v4 v4.0.1 h1:VwdxYT1lPOIBZolqNtN6GcpdOySgHhCFQNsbN5P7uh8=
+github.com/mailjet/mailjet-apiv3-go/v4 v4.0.1/go.mod h1:2SU3t6eh/uK6BSeBmdhpIUau99L4iPlIfbx4o4pAUQs=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=

--- a/main.go
+++ b/main.go
@@ -2,14 +2,20 @@ package main
 
 import (
 	"numenv_subscription_api/routes"
+	"numenv_subscription_api/services/discord"
 
 	"github.com/labstack/echo/v4"
 )
 
 func main() {
+  defer discord.DiscordClient()
+
+  // Starting server
 	e := echo.New()
 	routes.Subscribe(e)
-
-	e.Logger.Fatal(e.Start(":1323"))
+  
+	go func() {
+    e.Logger.Fatal(e.Start(":1323"))
+  }()
 }
 

--- a/main.go
+++ b/main.go
@@ -12,3 +12,4 @@ func main() {
 
 	e.Logger.Fatal(e.Start(":1323"))
 }
+

--- a/main.go
+++ b/main.go
@@ -8,14 +8,14 @@ import (
 )
 
 func main() {
-  defer discord.DiscordClient()
+  go func() {
+    discord.DiscordClient()
+  }()
 
   // Starting server
 	e := echo.New()
 	routes.Subscribe(e)
   
-	go func() {
-    e.Logger.Fatal(e.Start(":1323"))
-  }()
+  e.Logger.Fatal(e.Start(":1323"))
 }
 

--- a/middlewares/check_session_available.go
+++ b/middlewares/check_session_available.go
@@ -1,0 +1,46 @@
+package middlewares
+
+import (
+	"fmt"
+	"net/http"
+	"numenv_subscription_api/errors/logs"
+	"numenv_subscription_api/models/responses"
+	"numenv_subscription_api/repositories"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Verify that the queried session is not already full
+func IsSessionFull(next echo.HandlerFunc) echo.HandlerFunc {
+  return func(ctx echo.Context) error {
+
+    sess, err := repositories.GetSessionBySpeaker(
+      ctx.Request().Context(),
+      ctx.Param("speaker"),
+    )
+    count, err := repositories.GetSessionNumberSubscribersBySpeaker(ctx)
+    if err != nil || count == nil {
+      return err
+    }
+
+    if *count >= sess.NumSubscribers {
+      errMsg := fmt.Sprintf(
+        "Max number of subscribers reached for session : %s - \"%s\".", 
+        sess.Speaker,
+        sess.Name,
+      ) 
+      logs.Output(
+        logs.WARNING,
+        errMsg,
+      )
+      return ctx.JSON(
+        http.StatusNotAcceptable,
+        responses.ErrorResponse{
+          Message: errMsg,
+        },
+      )
+    }
+
+    return next(ctx)
+  }
+}

--- a/models/session.go
+++ b/models/session.go
@@ -7,7 +7,7 @@ type Session struct {
   Date           string `json:"date" binding:"required"`
   Type           string `json:"type" binding:"required"`
   DiscordRoleId  string `json:"discord_role_id" binding:"required"`
-  NumSubscribers string `json:"num_subscribers" binding:"required"`
+  NumSubscribers int    `json:"num_subscribers" binding:"required"`
 }
 
 func (m *Session) GetID() string {

--- a/models/session.go
+++ b/models/session.go
@@ -1,9 +1,12 @@
 package models
 
 type Session struct {
-	Id             string `json:"id"`
+  Id             string `json:"id" binding:"required"`
 	Name           string `json:"name" binding:"required"`
-	NumSubscribers string `json:"num_subscribers"`
+  Speaker        string `json:"speaker" binding:"required"`
+  Date           string `json:"date" binding:"required"`
+  Type           string `json:"type" binding:"required"`
+  NumSubscribers string `json:"num_subscribers" binding:"required"`
 }
 
 func (m *Session) GetID() string {

--- a/models/session.go
+++ b/models/session.go
@@ -6,6 +6,7 @@ type Session struct {
   Speaker        string `json:"speaker" binding:"required"`
   Date           string `json:"date" binding:"required"`
   Type           string `json:"type" binding:"required"`
+  DiscordRoleId  string `json:"discord_role_id" binding:"required"`
   NumSubscribers string `json:"num_subscribers" binding:"required"`
 }
 

--- a/repositories/session.go
+++ b/repositories/session.go
@@ -11,6 +11,78 @@ import (
 	"numenv_subscription_api/models"
 )
 
+func GetSessionById(ctx context.Context, sessionId string) (*models.Session, error) {
+  dbClient, err := db.Client()
+  if err != nil {
+    return nil, err
+  }
+
+  sess := &models.Session{}
+  q := "SELECT id, name, speaker, date, type, num_subscribers FROM sessions WHERE id=$1"
+  err = dbClient. 
+    QueryRowContext(ctx, q, sessionId). 
+    Scan(&sess.Id, &sess.Name, &sess.Speaker, &sess.Date, &sess.Type, &sess.NumSubscribers)
+  if err != nil {
+    logs.Output(
+      logs.ERROR,
+      fmt.Sprintf(
+        "Error occurred when retrieving session by Id (%s). Query : %u\n",
+        sessionId,
+        err,
+      ),
+    )
+    return nil, err
+  }
+  return sess, nil
+}
+
+func GetSessionBySpeaker(ctx context.Context, speaker string) (*models.Session, error) {
+  dbClient, err := db.Client()
+  if err != nil {
+    return nil, err
+  }
+
+  sess := &models.Session{}
+  q := "SELECT id, name, speaker, date, type, num_subscribers FROM sessions WHERE speaker=$1"
+  err = dbClient.
+    QueryRowContext(ctx, q, speaker).
+    Scan(&sess.Id, &sess.Name, &sess.Speaker, &sess.Date, &sess.Type, &sess.NumSubscribers)
+  if err != nil {
+    logs.Output(
+      logs.ERROR,
+      fmt.Sprintf(
+        "Error occurred when retrieving session by speaker name (%s). Query : %u\n",
+        speaker,
+        err,
+      ),
+    )
+    return nil, err
+  }
+  return sess, nil
+}
+
+func GetSessionNumberSubscribers(
+  ctx context.Context, 
+  speaker string,
+) (*int, error) {
+  dbClient, err := db.Client()
+  if err != nil {
+    return nil, err
+  }
+
+  var count int
+  err = dbClient.QueryRow("SELECT COUNT(*) FROM subscribers_to_sessions").Scan(&count)
+  if err != nil {
+    logs.Output(
+      logs.ERROR,
+      "Could not query the of rows.",
+    )
+    return nil, err
+  }
+
+  return &count, nil
+}
+
 func GetSessionByName(ctx context.Context, name string) (*models.Session, error) {
 	dbClient, err := db.Client()
 	if err != nil {

--- a/repositories/subscriber.go
+++ b/repositories/subscriber.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 )
 
-func Subscribe(ctx context.Context, user *models.Subscriber, sessionName string) error {
+func Subscribe(ctx context.Context, user *models.Subscriber, sessionId string) error {
 	client, err := db.Client()
 	if err != nil {
 		return err
@@ -25,7 +25,8 @@ func Subscribe(ctx context.Context, user *models.Subscriber, sessionName string)
     epitech_degree,
     discord_id,
     unique_str
-  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8);`
+  ) VALUES ($1, $2, $3, $4, $5, $6, NULLIF($7, ''), $8);`
+
 	id, err := uuid.NewRandom()
 	if err != nil {
 		logs.Output(
@@ -46,11 +47,10 @@ func Subscribe(ctx context.Context, user *models.Subscriber, sessionName string)
 	user.SetUniqueStr(uniqueStr.String())
 	err = db.Exec[models.Subscriber](ctx, client, q, *user)
 	if err != nil {
-		fmt.Println("Error inserting into database", err)
 		return err
 	}
 
-	sessionInfos, err := GetSessionByName(ctx, sessionName)
+	sessionInfos, err := GetSessionById(ctx, sessionId)
 	if err != nil {
 		return err
 	}

--- a/repositories/subscriber.go
+++ b/repositories/subscriber.go
@@ -50,6 +50,7 @@ func Subscribe(
 		return err
 	}
 
+  // Add metadata to intermediate table
 	err = AddSubscriberToSession(
     ctx,
     sessionInfos.Id,

--- a/repositories/subscriber_to_session.go
+++ b/repositories/subscriber_to_session.go
@@ -1,0 +1,62 @@
+package repositories
+
+import (
+  "context"
+  "fmt"
+  "numenv_subscription_api/db"
+  "numenv_subscription_api/errors/logs"
+
+  "github.com/google/uuid"
+)
+
+// Register data in the intermediate table
+// Those should include :
+// - The session ID
+// - The subscriber ID
+// - A unique string which is also sent by email to the subscriber
+func AddSubscriberToSession(
+  ctx context.Context, 
+  sessionId string, 
+  subscriberId string,
+  uniqueStr string,
+) error {
+	dbClient, err := db.Client()
+	if err != nil {
+		return err
+	}
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		logs.Output(
+			logs.ERROR,
+			"Error when generating unique string for a subscriber.",
+		)
+	}
+
+	q := `INSERT INTO subscribers_to_sessions (
+    id, 
+    sessions_id, 
+    subscribers_id,
+    unique_str
+  ) VALUES ($1, $2, $3, $4)`
+
+	_, err = dbClient.ExecContext(
+    ctx, 
+    q,
+    id,
+    sessionId,
+    subscriberId,
+    uniqueStr,
+  )
+	if err != nil {
+		logs.Output(logs.ERROR, fmt.Sprintf(
+			"Error occured with Add subscriber (id: %s) to session (id: %s) Query: %v\n",
+			sessionId,
+			subscriberId,
+			err,
+		))
+		return err
+	}
+
+	return nil
+}

--- a/routes/subscribe.go
+++ b/routes/subscribe.go
@@ -10,3 +10,4 @@ func Subscribe(e *echo.Echo) {
 	e.POST("/subscribe/:sessionName", controllers.Subscribe)
 	e.GET("/subscribers", controllers.ReadAll)
 }
+

--- a/routes/subscribe.go
+++ b/routes/subscribe.go
@@ -2,12 +2,16 @@ package routes
 
 import (
 	"numenv_subscription_api/controllers"
+	"numenv_subscription_api/middlewares"
 
 	"github.com/labstack/echo/v4"
 )
 
 func Subscribe(e *echo.Echo) {
-	e.POST("/subscribe/:sessionName", controllers.Subscribe)
-	e.GET("/subscribers", controllers.ReadAll)
+	e.GET("/subscribe", controllers.ReadAll)
+  // Groups
+  g := e.Group("/subscribe")
+  g.Use(middlewares.IsSessionFull)
+	g.POST("/:speaker", controllers.Subscribe, middlewares.IsSessionFull)
 }
 

--- a/services/discord/discord_client.go
+++ b/services/discord/discord_client.go
@@ -1,23 +1,49 @@
 package discord
 
 import (
-	"numenv_subscription_api/errors/logs"
 	"os"
+	"os/signal"
+	"numenv_subscription_api/errors/logs"
 
 	"github.com/bwmarrin/discordgo"
 )
 
-func DiscordClient() {
-  discordClient, err := discordgo.New("Bot " + os.Getenv("DISCORD_BOT_TOKEN"))
+func DiscordClient() error {
+  // Provide Discord bot connection token
+  session, err := discordgo.New(
+    "Bot " + os.Getenv("DISCORD_BOT_TOKEN"),
+  )
   if err != nil {
     logs.Output(
       logs.ERROR,
       "Could not connect to Discord server.",
     )
+    return err
   }
 
-  discordClient.Identify.Intents = discordgo.IntentsAll
+  // Providing Discord bot permissions
+  session.Identify.Intents = discordgo.IntentsAll
 
-  discordClient.GuildMemberRoleAdd("1175146908965159013", "236577940651900928", "1188650394335842344")
+  // Connection Discord bot
+  err = session.Open()
+  if err != nil {
+    logs.Output(
+      logs.ERROR,
+      "Could not connect Discord bot.",
+    )
+    return err
+  }
+  logs.Output(logs.INFO, "Discord bot connected.")
 
+  // Adding Discord bot commands
+  DiscordUserRegistrationCommand(session)
+
+  // Catching Ctrl + C signal to shutdown Discord bot
+  logs.Output(logs.INFO, "Press Ctrl+C to stop Discord bot.")
+  stop := make(chan os.Signal, 1)
+  signal.Notify(stop, os.Interrupt)
+  <- stop
+  
+
+  return nil
 }

--- a/services/discord/discord_client.go
+++ b/services/discord/discord_client.go
@@ -1,0 +1,23 @@
+package discord
+
+import (
+	"numenv_subscription_api/errors/logs"
+	"os"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func DiscordClient() {
+  discordClient, err := discordgo.New("Bot " + os.Getenv("DISCORD_BOT_TOKEN"))
+  if err != nil {
+    logs.Output(
+      logs.ERROR,
+      "Could not connect to Discord server.",
+    )
+  }
+
+  discordClient.Identify.Intents = discordgo.IntentsAll
+
+  discordClient.GuildMemberRoleAdd("1175146908965159013", "236577940651900928", "1188650394335842344")
+
+}

--- a/services/discord/discord_command.go
+++ b/services/discord/discord_command.go
@@ -57,7 +57,7 @@ func registerSubscriberDiscordIdCallback(
           opt.StringValue(),
         )
         if err != nil {
-          err := session.InteractionRespond(
+          sessErr := session.InteractionRespond(
             interaction.Interaction,
             &discordgo.InteractionResponse {
               Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -66,14 +66,14 @@ func registerSubscriberDiscordIdCallback(
               },
             },
           )
-          if err != nil {
+          if sessErr != nil {
             logs.Output(
               logs.ERROR,
-              "Could not initiate bot response.",
+              "Could not initiate Discord bot session response.",
             )
           }
+          return
         }
-        fmt.Println(sess)
         err = session.InteractionRespond(
           interaction.Interaction,
           &discordgo.InteractionResponse {
@@ -90,6 +90,14 @@ func registerSubscriberDiscordIdCallback(
           os.Getenv("DISCORD_GUILD_ID"),
           interaction.Member.User.ID,
           sess.DiscordRoleId,
+        )
+        session.GuildMemberNickname(
+          os.Getenv("DISCORD_GUILD_ID"),
+          interaction.Member.User.ID,
+          fmt.Sprintf(
+            "%s (Poet)",
+            interaction.Member.User.Username,
+          ),
         )
         if err != nil {
           logs.Output(

--- a/services/discord/discord_command.go
+++ b/services/discord/discord_command.go
@@ -1,0 +1,103 @@
+package discord
+
+import (
+	"fmt"
+	"numenv_subscription_api/errors/logs"
+	"numenv_subscription_api/services"
+	"os"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func DiscordUserRegistrationCommand(
+  discordClient *discordgo.Session,
+) {
+  appCommand := []*discordgo.ApplicationCommand {
+    {
+      Name: "register",
+      Description: "Registrate a new subscriber.",
+      Options: []*discordgo.ApplicationCommandOption {
+        {
+          Name: "key",
+          Description: "The key provided to register to a session.",
+          Type: discordgo.ApplicationCommandOptionString,
+        },
+      },
+    },
+  }
+
+  _, err := discordClient.ApplicationCommandBulkOverwrite(
+    os.Getenv("DISCORD_APP_ID"),
+    os.Getenv("DISCORD_GUILD_ID"),
+    appCommand,
+  )
+  if err != nil {
+    logs.Output(
+      logs.ERROR,
+      "Could not create the Discord application command.",
+    )
+  }
+
+  discordClient.AddHandler(registerSubscriberDiscordIdCallback)
+}
+
+// Callback function provided to the `.AddHandler` method
+// to trigger when a user triggers the `/register` command
+func registerSubscriberDiscordIdCallback(
+  session *discordgo.Session, 
+  interaction *discordgo.InteractionCreate,
+) {
+  if interaction.Type == discordgo.InteractionApplicationCommand {
+    options := interaction.ApplicationCommandData().Options
+    for _, opt := range options {
+      switch opt.Type {
+      case discordgo.ApplicationCommandOptionString:
+        sess, err := services.RegisterDiscordId(
+          interaction.Member.User.ID,
+          opt.StringValue(),
+        )
+        if err != nil {
+          err := session.InteractionRespond(
+            interaction.Interaction,
+            &discordgo.InteractionResponse {
+              Type: discordgo.InteractionResponseChannelMessageWithSource,
+              Data: &discordgo.InteractionResponseData {
+                Content: "Merci d'entrer votre clé communiquée par mail.",
+              },
+            },
+          )
+          if err != nil {
+            logs.Output(
+              logs.ERROR,
+              "Could not initiate bot response.",
+            )
+          }
+        }
+        fmt.Println(sess)
+        err = session.InteractionRespond(
+          interaction.Interaction,
+          &discordgo.InteractionResponse {
+            Type: discordgo.InteractionResponseChannelMessageWithSource,
+            Data: &discordgo.InteractionResponseData {
+              Content: fmt.Sprintf(
+                `Vous êtes inscrit à la session : **%s** - *%s*. Elle aura lieu le %s.`,
+                sess.Speaker, sess.Name, sess.Date,
+              ),
+            },
+          },
+        )
+        session.GuildMemberRoleAdd(
+          os.Getenv("DISCORD_GUILD_ID"),
+          interaction.Member.User.ID,
+          sess.DiscordRoleId,
+        )
+        if err != nil {
+          logs.Output(
+            logs.ERROR,
+            "Could not initiate bot response.",
+          )
+        }
+      }
+    }
+  }
+}

--- a/services/discord/discord_command.go
+++ b/services/discord/discord_command.go
@@ -15,7 +15,7 @@ func DiscordUserRegistrationCommand(
   appCommand := []*discordgo.ApplicationCommand {
     {
       Name: "register",
-      Description: "Registrate a new subscriber.",
+      Description: "Register a new subscriber.",
       Options: []*discordgo.ApplicationCommandOption {
         {
           Name: "key",

--- a/services/mail/mail_content.go
+++ b/services/mail/mail_content.go
@@ -42,7 +42,7 @@ func FormatContent(session string, uniqueStr string) string {
                 text-decoration: none;
               '
             >
-              Rejoindre le server
+              Rejoindre le serveur
             </a>
           </td>
         </tr>

--- a/services/mail/mail_content.go
+++ b/services/mail/mail_content.go
@@ -1,0 +1,56 @@
+package mail
+
+import (
+  "fmt"
+)
+
+func FormatContent(session string, uniqueStr string) string {
+  htmlContent := fmt.Sprintf(
+    `<!DOCTYPE PUBLIC “-//W3C//DTD XHTML 1.0 Transitional//EN” “https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd”>
+    <html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title></title>
+    </head>
+    <body>
+      <p>Merci pour votre inscription à la session : %s.</p>
+
+      <p>Pour finaliser votre inscription et pouvoir poser vos questions et échanger avec les
+      autres participant.e.s, merci de rejoindre le serveur Discord Envnum et d'utiliser la commande 
+      /register avec le code de connexion suivant : %s.
+      </p>
+
+      <table
+        width='100%'
+        align='center'
+        border='0'
+        cellspacing='0'
+        cellpadding='0'
+        style="table-layout: fixed;"
+      >
+        <tr>
+          <td aligh='center'>
+            <a 
+              href='https://discord.gg/e3C7v8qPa5' 
+              style='
+                background-color: #4169E1;
+                color: #000000;
+                font-size: 1.3em;
+                padding: 10px;
+                border-radius: 10px;
+                text-decoration: none;
+              '
+            >
+              Rejoindre le server
+            </a>
+          </td>
+        </tr>
+      </table>
+    </body>`, 
+    session,
+    uniqueStr,
+  )
+  
+  return htmlContent
+}

--- a/services/mail/mail_content_test.go
+++ b/services/mail/mail_content_test.go
@@ -1,0 +1,63 @@
+package mail
+
+import (
+  "fmt"
+  "testing"
+  "github.com/google/uuid"
+) 
+
+func TestFormatContent(t *testing.T) {
+  uniqueStr, err := uuid.NewRandom()
+  if err != nil {
+    fmt.Println("Could not generate a UUID.")
+  }
+
+  got := FormatContent("First session", uniqueStr.String())
+  want := fmt.Sprintf(`<!DOCTYPE PUBLIC “-//W3C//DTD XHTML 1.0 Transitional//EN” “https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd”>
+    <html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title></title>
+    </head>
+    <body>
+      <p>Merci pour votre inscription à la session : First session</p>
+
+      <p>Pour finaliser votre inscription et pouvoir poser vos questions et échanger avec les
+      autres participant.e.s, merci de rejoindre le serveur Discord Envnum et d'utiliser la commande 
+      /register avec le code de connexion suivant : %s.
+      </p>
+
+      <table
+        width='100%'
+        align='center'
+        border='0'
+        cellspacing='0'
+        cellpadding='0'
+        style="table-layout: fixed;"
+      >
+        <tr>
+          <td aligh='center'>
+            <a 
+              href='https://discord.gg/e3C7v8qPa5' 
+              style='
+                background-color: #4169E1;
+                color: #000000;
+                font-size: 1.3em;
+                padding: 10px;
+                border-radius: 10px;
+                text-decoration: none;
+              '
+            >
+              Rejoindre le server
+            </a>
+          </td>
+        </tr>
+      </table>
+    </body>`, uniqueStr)
+
+  // Assert
+  if got != want {
+    t.Errorf("got %q, wanted %q", got, want)
+  }
+}

--- a/services/mail/send_mail.go
+++ b/services/mail/send_mail.go
@@ -1,0 +1,35 @@
+package mail
+
+import (
+	"fmt"
+	"numenv_subscription_api/errors/logs"
+	"os"
+
+	. "github.com/mailjet/mailjet-apiv3-go"
+)
+
+func SendMail(address string, session string, uniqueStr string) {
+	mailjetClient := NewMailjetClient(
+      os.Getenv("MAILJET_API_KEY"),
+      os.Getenv("MAILJET_API_SECRET"),
+    )
+	email := &InfoSendMail {
+      FromEmail: "registration@envnum.fr",
+      FromName: "Team Envnum",
+      Subject: fmt.Sprintf("Envnum{2024} - Inscription %s", session),
+      HTMLPart: FormatContent(session, uniqueStr),
+      Recipients: []Recipient {
+        Recipient {
+          Email: address,
+        },
+      },
+    }
+  
+	_, err := mailjetClient.SendMail(email)
+	if err != nil {
+    logs.Output(
+      logs.ERROR,
+      "Could not send the email.",
+    )
+	}
+}

--- a/services/mail/send_mail.go
+++ b/services/mail/send_mail.go
@@ -14,7 +14,7 @@ func SendMail(address string, session string, uniqueStr string) {
       os.Getenv("MAILJET_API_SECRET"),
     )
 	email := &InfoSendMail {
-      FromEmail: "registration@envnum.fr",
+      FromEmail: os.Getenv("MAIL_SENDER_ADDRESS"),
       FromName: "Team Envnum",
       Subject: fmt.Sprintf("Envnum{2024} - Inscription %s", session),
       HTMLPart: FormatContent(session, uniqueStr),

--- a/services/mail/send_mail.go
+++ b/services/mail/send_mail.go
@@ -14,7 +14,7 @@ func SendMail(address string, session string, uniqueStr string) {
       os.Getenv("MAILJET_API_SECRET"),
     )
 	email := &InfoSendMail {
-      FromEmail: os.Getenv("MAIL_SENDER_ADDRESS"),
+      FromEmail: os.Getenv("MAILJET_SENDER_ADDRESS"),
       FromName: "Team Envnum",
       Subject: fmt.Sprintf("Envnum{2024} - Inscription %s", session),
       HTMLPart: FormatContent(session, uniqueStr),

--- a/services/register_discord_id.go
+++ b/services/register_discord_id.go
@@ -1,0 +1,17 @@
+package services
+
+import (
+  "numenv_subscription_api/models"
+	"numenv_subscription_api/repositories"
+)
+
+func RegisterDiscordId(discordId string, uniqueStr string) (*models.Session, error) {
+  repositories.RegisterUserDiscordId(discordId, uniqueStr)
+
+  sess, err := repositories.GetSessionByUniqueStr(uniqueStr)
+  if err != nil {
+    return nil, err
+  }
+
+  return sess, nil
+}

--- a/services/subscribe.go
+++ b/services/subscribe.go
@@ -5,24 +5,23 @@ import (
 	"numenv_subscription_api/repositories"
   "numenv_subscription_api/errors/logs"
 	"numenv_subscription_api/services/mail"
-  "numenv_subscription_api/services/discord"
 
-	"github.com/labstack/echo/v4"
+  "github.com/labstack/echo/v4"
   "github.com/google/uuid"
 )
 
+// Register a user to the database and creates a unique string 
+// that is used to also register the same user on Discord so 
+// it can access the corresponding channel
 func Subscribe(
   c echo.Context, 
   user *models.Subscriber, 
   speaker string,
 ) error {
-  discord.DiscordClient()
-  sess, err := repositories.GetSessionBySpeaker(c.Request().Context(), speaker)
-
-	err = repositories.Subscribe(c.Request().Context(), user, sess.Id)
-	if err != nil {
-		return err
-	}
+  sess, err := repositories.GetSessionBySpeaker(
+    c.Request().Context(), 
+    speaker,
+  )
 
   uniqueStr, err := uuid.NewRandom()
   if err != nil {
@@ -32,10 +31,22 @@ func Subscribe(
     )
   }
 
+	err = repositories.Subscribe(
+    c.Request().Context(), 
+    user,
+    sess.Id,
+    uniqueStr.String(),
+  )
+	if err != nil {
+		return err
+	}
+
   mail.SendMail(user.Email, sess.Name, uniqueStr.String())
+
 	return nil
 }
 
+// Get all the subscribers
 func ReadAll(c echo.Context) ([]*models.Subscriber, error) {
 	result, err := repositories.ReadAll(c.Request().Context())
 	if err != nil {

--- a/services/subscribe.go
+++ b/services/subscribe.go
@@ -3,17 +3,31 @@ package services
 import (
 	"numenv_subscription_api/models"
 	"numenv_subscription_api/repositories"
+  "numenv_subscription_api/errors/logs"
 	"numenv_subscription_api/services/mail"
+  "numenv_subscription_api/services/discord"
 
 	"github.com/labstack/echo/v4"
+  "github.com/google/uuid"
 )
 
-func Subscribe(c echo.Context, user *models.Subscriber, sessionName string) error {
-	err := repositories.Subscribe(c.Request().Context(), user, sessionName)
+func Subscribe(c echo.Context, user *models.Subscriber, speaker string) error {
+  discord.DiscordClient()
+  sess, err := repositories.GetSessionBySpeaker(c.Request().Context(), speaker)
+
+	err = repositories.Subscribe(c.Request().Context(), user, sess.Id)
 	if err != nil {
 		return err
 	}
-	mail.Send_mail()
+
+  uniqueStr, err := uuid.NewRandom()
+  if err != nil {
+    logs.Output(
+      logs.ERROR,
+      "Error when generating unique string for a subscriber.",
+    )
+  }
+  mail.SendMail("romain.mularczyk@gmail.com", sess.Name, uniqueStr.String())
 	return nil
 }
 

--- a/services/subscribe.go
+++ b/services/subscribe.go
@@ -11,7 +11,11 @@ import (
   "github.com/google/uuid"
 )
 
-func Subscribe(c echo.Context, user *models.Subscriber, speaker string) error {
+func Subscribe(
+  c echo.Context, 
+  user *models.Subscriber, 
+  speaker string,
+) error {
   discord.DiscordClient()
   sess, err := repositories.GetSessionBySpeaker(c.Request().Context(), speaker)
 
@@ -27,7 +31,8 @@ func Subscribe(c echo.Context, user *models.Subscriber, speaker string) error {
       "Error when generating unique string for a subscriber.",
     )
   }
-  mail.SendMail("romain.mularczyk@gmail.com", sess.Name, uniqueStr.String())
+
+  mail.SendMail(user.Email, sess.Name, uniqueStr.String())
 	return nil
 }
 

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-#
+
 set -a
 source .env
 set +a


### PR DESCRIPTION
# Add formatting email functions
* Refactor mail content
* Add mail formatting function unit test

# Add mailjet to dependencies
* Add mailjet v3
* Add mailjet v4

# Add air to git ignored files
* air.toml

# Add discord client
* discord client connection with discord bot token

# Refactor email addresses to variables
* Sender email address
* Receiver email address

# Parallelize main.go
* Run server + discord bot in parallel

# Adding function documentation
* Services
* Repositories

# Add services and repositories
* Add discord_register_id service
* Refactor subscribers-to-sessions repositories to populate intermediate table metadata
* Add repository querying sessions by unique str

# Add discord services
* Discord client connection
* Discord /register command
* Fix /register command error handling (when unique str not found in the intermediate table)

# Routing
* Add groups to restrict /subscribe POST route with middlewares

# Middlewares
* Add middleware checking max number of subscribers per session

# Models
* Modify num_subscribers property to `int`

# Fixes
* Change mailjet sender address environment variable name
* Change logs errors flag to remove date
* Typo in mail content